### PR TITLE
Use new GitHub Actions for Haskell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ on:
     branches: [master]
 
 jobs:
-  build:
-    name: ghc ${{ matrix.ghc }}
-    runs-on: ubuntu-16.04
+  cabal:
+    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         cabal: ["3.0"]
@@ -18,21 +18,39 @@ jobs:
           - "8.6.5"
           - "8.8.3"
           - "8.10.1"
+        os:
+	  - ubuntu-latest
+	  - macOS-latest
+	  - windows-latest
+	# use only latest GHC on macOS and Windows
+	exclude:
+	  - os: macOS-latest
+	    ghc: 8.8.3
+	  - os: macOS-latest
+	    ghc: 8.6.5
+	  - os: macOS-latest
+	    ghc: 8.4.4
+	  - os: windows-latest
+	    ghc: 8.8.3
+	  - os: windows-latest
+	    ghc: 8.6.5
+	  - os: windows-latest
+	    ghc: 8.4.4
 
     steps:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1
+    - uses: actions/setup-haskell@v1.1
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
 
     - uses: actions/cache@v1
-      name: Cache ~/.cabal/store
+      name: Cache cabal-store
       with:
-        path: ~/.cabal/store
+        path: ${{ cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}-cabal
 
     - name: Build
@@ -43,3 +61,35 @@ jobs:
     - name: Test
       run: |
         cabal test --enable-tests
+
+  stack:
+    name: stack / ghc ${{ matrix.ghc }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+	stack: ["2.1.3"]
+	ghc: ["8.8.3"]
+
+    steps:
+    - uses: actions/checkout@v2
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
+
+    - uses: actions/setup-haskell@v1.1
+      name: Setup Haskell Stack
+      with:
+        ghc-version: ${{ matrix.ghc }}
+	stack-version: ${{ matrix.stack }}
+
+    - uses: actions/cache@v1
+      name: Cache ~/.stack
+      with:
+        path: ~/.stack
+        key: ${{ runner.os }}-${{ matrix.ghc }}-stack
+
+    - name: Build
+      run: |
+        stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
+
+    - name: Test
+      run: |
+        stack test --system-ghc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         cabal: ["3.0"]
         ghc:
           - "8.4.4"
           - "8.6.5"
           - "8.8.3"
           - "8.10.1"
-        os:
-	  - ubuntu-latest
-	  - macOS-latest
-	  - windows-latest
 	# use only latest GHC on macOS and Windows
 	exclude:
 	  - os: macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,20 +19,19 @@ jobs:
           - "8.6.5"
           - "8.8.3"
           - "8.10.1"
-	# use only latest GHC on macOS and Windows
-	exclude:
-	  - os: macOS-latest
-	    ghc: 8.8.3
-	  - os: macOS-latest
-	    ghc: 8.6.5
-	  - os: macOS-latest
-	    ghc: 8.4.4
-	  - os: windows-latest
-	    ghc: 8.8.3
-	  - os: windows-latest
-	    ghc: 8.6.5
-	  - os: windows-latest
-	    ghc: 8.4.4
+        exclude:
+          - os: macOS-latest
+            ghc: 8.8.3
+          - os: macOS-latest
+            ghc: 8.6.5
+          - os: macOS-latest
+            ghc: 8.4.4
+          - os: windows-latest
+            ghc: 8.8.3
+          - os: windows-latest
+            ghc: 8.6.5
+          - os: windows-latest
+            ghc: 8.4.4
 
     steps:
     - uses: actions/checkout@v2
@@ -64,8 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-	stack: ["2.1.3"]
-	ghc: ["8.8.3"]
+        stack: ["2.1.3"]
+        ghc: ["8.8.3"]
 
     steps:
     - uses: actions/checkout@v2
@@ -75,7 +74,7 @@ jobs:
       name: Setup Haskell Stack
       with:
         ghc-version: ${{ matrix.ghc }}
-	stack-version: ${{ matrix.stack }}
+        stack-version: ${{ matrix.stack }}
 
     - uses: actions/cache@v1
       name: Cache ~/.stack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
     - uses: actions/setup-haskell@v1.1
+      id: setup-haskell-cabal
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
@@ -46,7 +47,7 @@ jobs:
     - uses: actions/cache@v1
       name: Cache cabal-store
       with:
-        path: ${{ cabal-store }}
+        path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}-cabal
 
     - name: Build


### PR DESCRIPTION
Attempt to build everything on GitHub Actions.

Now matrix on GitHub actions looks like this:

* Build with Cabal 3.0 and GHC 8.10.1, 8.8.3, 8.6.5, 8.4.4 on Ubuntu
* Build with Cabal 3.0 and GHC 8.10.1 on Windows
* Build with Cabal 3.0 and GHC 8.10.1 on macOS
* Build with Stack 2.1.3 and GHC 8.8.3 on Ubuntu