### PR TITLE
Update Validation.hs

### DIFF
--- a/src/Validation.hs
+++ b/src/Validation.hs
@@ -415,7 +415,7 @@ instance (Semigroup e, Semigroup a, Monoid a) => Monoid (Validation e a) where
     mappend = (<>)
     {-# INLINE mappend #-}
 
-{- | This instance if the most important instance for the 'Validation' data
+{- | This instance is the most important instance for the 'Validation' data
 type. It's responsible for the many implementations. And it allows to accumulate
 errors while performing validation or combining the results in the applicative
 style.


### PR DESCRIPTION
Just noticed a typo in the `Applicative` instance haddock string ("This instance _if_ the most..." -> "This instance _is_ the most...").

(I see in the contributing guide that you guys prefer to have an issue corresponding to each PR; hopefully my assumption is correct, that a one-character typo fix is out of the scope of that rule ;) )