### PR TITLE
Changelog: Fix links to issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ The changelog is available [on GitHub][2].
 
 ## 🥧 0.1.0.1 — Mar 14, 2021
 
-* [#57](https://github.com/kowainik/relude/issues/57):
+* [#57](https://github.com/kowainik/validation-selective/issues/57):
   Support GHC-9.0. Upgrade minor version to 8.10.4 and 8.8.4.
 
 ## 0.1.0.0 — May 5, 2020
 
-* [#41](https://github.com/kowainik/relude/issues/41):
+* [#41](https://github.com/kowainik/validation-selective/issues/41):
   Support GHC-8.10.1.
-* [#24](https://github.com/kowainik/relude/issues/24):
+* [#24](https://github.com/kowainik/validation-selective/issues/24):
   Add `validationAll`, `when*` and `maybe*` combinators into
   `Validation.Combinators`.
 


### PR DESCRIPTION
I realized the Changelog linked to issues of kowainik/relude instead of kowainik/validation-selective which doesn't seem to be the intended destination. I updated the links accordingly.