### PR TITLE
Support up to GHC 9.6

### DIFF
--- a/validation-selective.cabal
+++ b/validation-selective.cabal
@@ -37,7 +37,7 @@ source-repository head
   location:            https://github.com/kowainik/validation-selective.git
 
 common common-options
-  build-depends:       base >= 4.12 && < 4.18
+  build-depends:       base >= 4.12 && < 4.19
 
   ghc-options:         -Wall
                        -Wcompat


### PR DESCRIPTION
This seems all that's required to run all the way to GHC 9.4. I haven't run any tests though.