### PR TITLE
Support selective-0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 `validation-selective` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 0.2.0.1 — 
+
+* Allow `selective-0.7` 
+
 ## 0.2.0.0 — Mar 1, 2023
 
 * [#62](https://github.com/kowainik/validation-selective/issues/62):

--- a/validation-selective.cabal
+++ b/validation-selective.cabal
@@ -80,7 +80,7 @@ library
   exposed-modules:     Validation
                          Validation.Combinators
   build-depends:       deepseq >= 1.4.3.0 && < 1.6
-                     , selective >= 0.3 && < 0.7
+                     , selective >= 0.3 && < 0.8
 
 test-suite validation-selective-test
   import:              common-options


### PR DESCRIPTION
PR tested with `cabal build --constraint="selective ==0.7"`