### PR TITLE
9.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 `validation-selective` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 0.2.0.1 — 
+
+* Allow `selective-0.7` 
+
 ## 0.2.0.0 — Mar 1, 2023
 
 * [#62](https://github.com/kowainik/validation-selective/issues/62):

--- a/validation-selective.cabal
+++ b/validation-selective.cabal
@@ -37,7 +37,7 @@ source-repository head
   location:            https://github.com/kowainik/validation-selective.git
 
 common common-options
-  build-depends:       base >= 4.12 && < 4.20
+  build-depends:       base >= 4.12 && < 4.21
 
   ghc-options:         -Wall
                        -Wcompat


### PR DESCRIPTION
I builds with the following so I intend to merge this and revise the Hackage bound.

```
cabal build -w ~/ghc-9.10/bin/ghc --allow-newer
```

(also add missing changelog entry)