### PR TITLE
Support GHC 9.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         # We must always use the latest version of cabal because
         # otherwise ghc-paths, which is a dependency of doctest,
         # can't be configured.
-        cabal: ["3.10"]
+        cabal: ["3.16"]
         ghc:
           - "8.6.5"
           - "8.8.4"
@@ -32,6 +32,7 @@ jobs:
           - "9.8.1"
           - "9.10.1"
           - "9.12.1"
+          - "9.14.1"
         exclude:
           - os: macOS-latest
             ghc: 9.6.3

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,3 @@
+packages: validation-selective.cabal
+
+allow-newer: boring:base

--- a/validation-selective.cabal
+++ b/validation-selective.cabal
@@ -37,7 +37,7 @@ source-repository head
   location:            https://github.com/kowainik/validation-selective.git
 
 common common-options
-  build-depends:       base >= 4.12 && < 4.22
+  build-depends:       base >= 4.12 && < 4.23
 
   ghc-options:         -Wall
                        -Wcompat


### PR DESCRIPTION
Use cabal.project to relax boring's bounds.  This will allow CI to run, but not leak into released sdists.